### PR TITLE
Increase timeout for fedora download from default (10) to 100.

### DIFF
--- a/roles/hydra-stack/tasks/fedora.yml
+++ b/roles/hydra-stack/tasks/fedora.yml
@@ -1,7 +1,7 @@
 ---
 - name: download fedora
   become: yes
-  get_url: url=http://repo1.maven.org/maven2/org/fcrepo/fcrepo-webapp/4.1.0/fcrepo-webapp-4.1.0.war owner={{ install_user }} group={{ install_group }} dest={{ install_path }}/fcrepo-webapp-4.1.0.war
+  get_url: url=http://repo1.maven.org/maven2/org/fcrepo/fcrepo-webapp/4.1.0/fcrepo-webapp-4.1.0.war owner={{ install_user }} group={{ install_group }} dest={{ install_path }}/fcrepo-webapp-4.1.0.war timeout=100
 
 - name: make fedora data dir
   file: owner=tomcat7 group=tomcat7 state=directory path=/opt/fedora-data


### PR DESCRIPTION
I was getting repeated timeouts on this task so just upped it by an order of magnitude. That made it work for me; the number I chose was more or less arbitrary, though.
