### PR TITLE
Add sudo rule so that capistrano_user can restart resque-pool.

### DIFF
--- a/roles/housekeeping/tasks/users_groups_dirs.yml
+++ b/roles/housekeeping/tasks/users_groups_dirs.yml
@@ -29,3 +29,6 @@
   with_nested:
     - [ "{{ capistrano_user }}", 'ubuntu' ]
     - "{{ keys_to_add }}"
+
+- name: allow capistrano user to restart resque-pool
+  template: src=resque-restart-users dest=/etc/sudoers.d/resque-restart-users validate='visudo -cf %s'

--- a/roles/housekeeping/templates/resque-restart-users
+++ b/roles/housekeeping/templates/resque-restart-users
@@ -1,0 +1,1 @@
+{{ capistrano_user }} ALL=(ALL) NOPASSWD: /usr/sbin/service resque-pool restart


### PR DESCRIPTION
Resque loads the application on startup and therefore needs to be
restarted when code is deployed.
