### PR TITLE
Deploy newfia from inside VM

### DIFF
--- a/roles/newfia/tasks/main.yml
+++ b/roles/newfia/tasks/main.yml
@@ -1,0 +1,45 @@
+---
+# ROLE: newfia
+# roles/newfia/tasks/main.yml (in sufia-prod-ubuntu-vagrant repo)
+#
+# Does a minimal install of newfia in devlopment mode to bootstrap a capistrano deployment to the VM
+  
+- name: create deployment keypair for vagrant user
+  user: 
+      name: vagrant 
+      generate_ssh_key: yes 
+      ssh_key_file: .ssh/id_rsa
+             
+- name: read public key
+  slurp: 
+      src: /home/vagrant/.ssh/id_rsa.pub
+  register: public_key      
+  
+- name: add vagrant user public key to deploy user
+  become: yes
+  authorized_key: 
+      user: deploy 
+      key: "{{ public_key.content | b64decode }}"
+
+- name: clone newfia repo 
+  git: 
+      repo: https://github.com/curationexperts/newfia.git 
+      dest: /home/vagrant/newfia
+
+- name: setup newfia - i.e. bundle install
+  shell: bundle install chdir=/home/vagrant/newfia
+      
+- name: deploy newfia to production directories with capistrano
+  shell: cap internal_vm deploy chdir=/home/vagrant/newfia  
+  
+- name: restart tomcat
+  become: true
+  service: 
+      name: tomcat7
+      state: restarted
+
+- name: restart apache
+  become: true
+  service: 
+      name: apache2
+      state: restarted


### PR DESCRIPTION
Adds a role to clone newfia inside the guest VM and use that to
deploy to the production directories.

Newfia stage 'internal_vm' added to newfia that deploys code
within a vagrant VM
