### PR TITLE
Refactor to allow finding opt volume ID on-reruns

### DIFF
--- a/create_ec2.yml
+++ b/create_ec2.yml
@@ -9,8 +9,6 @@
   name: setup
   user: ubuntu
   gather_facts: true
-  vars:
-    ec2_vol_1: "{{ hostvars['localhost'].ec2_vol }}"
   roles:
     - { role: packages }
     - { role: ec2 }

--- a/roles/ec2/tasks/ec2_crons.yml
+++ b/roles/ec2/tasks/ec2_crons.yml
@@ -3,6 +3,20 @@
 # TODO
 # add backup and cleanup scripts to crontab
 # be sure backup_opt runs at least an hour after the postgres backups
+
+- name: get EC2 instance_id
+  action: ec2_facts
+  register: instance_facts
+
+- name: get volume_ID for data volume # used in snapshot_backup.j2 template
+  ec2_vol:
+    aws_access_key: "{{ ec2_access_key }}"
+    aws_secret_key: "{{ ec2_secret_key }}"
+    instance: "{{ instance_facts.ansible_ec2_instance_id }}"
+    device_name: /dev/sdf
+    state: list
+  register: ec2_vol_1
+
 - name: add ec2 directory
   become: yes
   file: owner=root group=root path=/etc/ec2-backups state=directory

--- a/roles/launch_ec2/tasks/main.yml
+++ b/roles/launch_ec2/tasks/main.yml
@@ -1,3 +1,9 @@
+---
+# ROLE: launch_ec2
+# roles/launch_ec2/tasks/main.yml
+#
+# Launches a new ec2 instance and attaches dedicated data volume
+
 - name: provision an ec2 instance
   ec2:
     key_name: "{{ ec2_key }}" 
@@ -14,17 +20,11 @@
       Name: "{{ aws_tag }}"
     instance_tags: 
       Name: "{{ aws_tag }}"
+    volumes:
+          - device_name: /dev/sdf
+            volume_size: 40
+            delete_on_termination: true
   register: ec2
-
-- name: attach volume to new instance
-  ec2_vol:
-    instance: "{{ ec2.instance_ids }}"
-    region: "{{ ec2_region }}"
-    device_name: /dev/sdf
-    volume_size: 40
-    aws_access_key: "{{ ec2_access_key }}"
-    aws_secret_key: "{{ ec2_secret_key }}"
-  register: ec2_vol
 
   # first stab at dynamic inventory management on ec2
   # finishing this is out of scope for current project
@@ -38,4 +38,4 @@
   with_items: ec2.instances
 
 - name: give ssh time to come up
-  pause: minutes=2
+  wait_for: host={{ item.public_ip }} port=22 state=started


### PR DESCRIPTION
Allows ec2_crons to be called independently from machine creation.
