### PR TITLE
adds cap shared log dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ To create, set up an ec2 instance:
 There's another playbook called configure.yml. It's included by create_ec2 but can also be run separately. This playbook IS idempotent, so it can be used to change configuration at will. Also, AWS-related tasks have been removed (let us know if you run into anything!) so it should be more generalizable. Note that to run this playbook you must specify a hosts variable (see comment in configure.yml).
 
 ## Deployment
-This project expects your code to be deployed with [Capistrano](http://capistranorb.com/). In your Hydra head (the codebase you're deploying), set the Capistrano `:deploy_to` directory to match the capistrano_setup role's `project_base` variable. If you use the default value for `project_base` in the capistrano_setup role, you should use 
+This project expects your code to be deployed with [Capistrano](http://capistranorb.com/). In your Hydra head (the codebase you're deploying), configure Capistrano for your server(s). In `config/deploy.rb` and/or in `config/deploy/<yourenv>.rb` you must:  
+	* share the log directory by including `log` in your Capistrano `linked_dirs` list and  
+	* set the Capistrano `:deploy_to` directory to match the capistrano_setup role's `project_base` variable. If you use the default value for `project_base` in the capistrano_setup role, you should use 
 ```
 set :deploy_to, '/opt/sufia-project'
 ```
-in `config/deploy.rb` and/or in `config/deploy/<yourenv>.rb`  
 
 ## Vagrant
 [Vagrant](http://docs.vagrantup.com/v2/)

--- a/roles/capistrano_setup/tasks/main.yml
+++ b/roles/capistrano_setup/tasks/main.yml
@@ -15,6 +15,7 @@
   file: path={{ item }} state=directory owner={{ capistrano_user }} group={{ capistrano_group }}
   with_items:
     - "{{ project_base }}/shared/config/initializers"
+    - "{{ project_base }}/shared/log"
     - "{{ project_base }}/releases"
     - /home/{{ capistrano_user }}/.ssh
 


### PR DESCRIPTION
Scripts may work without this fix, but this makes the location of the resque-pool logs easy to find, so we agreed to merge this commit in. 
