### PR TITLE
Move opt drive mounting for EC2

### DIFF
--- a/create_ec2.yml
+++ b/create_ec2.yml
@@ -1,5 +1,5 @@
 - hosts: localhost
-  name: create
+  name: create a new EC2 instance
   connection: local
   gather_facts: False
   roles:
@@ -11,6 +11,7 @@
   gather_facts: true
   roles:
     - { role: packages }
+    - { role: mount_opt, data_device: /dev/xvdf }
     - { role: ec2 }
 
 - include: configure.yml hosts=newboxes

--- a/roles/ec2/meta/main.yml
+++ b/roles/ec2/meta/main.yml
@@ -1,5 +1,0 @@
----
-# FILE: roles/ec2/meta/main.yml
-
-dependencies:
-  - { role: mount_opt, data_device: /dev/xvdf }


### PR DESCRIPTION
Makes the opt (data) drive setup clearer by moving it to a top-level role 
instead of burying the configuration in a meta dependency.

Closes #55 
