### PR TITLE
removes private_key_file from ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,4 +1,6 @@
 [defaults]
-private_key_file=/Users/alicia/.ssh/devtest.pem
+# automated host key checking may be added in 2.0
+# see https://github.com/ansible/ansible-modules-core/issues/575
+# 
 host_key_checking = False
 


### PR DESCRIPTION
Closes #85.
I'm happy to merge some or all of today's PRs into master if we want to avoid the merge commits in the commit history. Feedback welcome.
