### PR TITLE
Adjusts instance from m3 to m4, for lower operation costs.

### DIFF
--- a/roles/launch_ec2/defaults/main.yml
+++ b/roles/launch_ec2/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # roles/launch_ec2/defaults/main.yml
 ec2_region: us-east-1
-ec2_instance_type: m3.medium # a moderate instance size 
-ec2_image: ami-b9c525d2 # ubuntu 14.04 LTS 64-bit for us-east-1
+ec2_instance_type: m4.medium # a moderate instance size 
+ec2_image: ami-a95f79c3 # ubuntu 14.04 LTS 64-bit for us-east-1
 aws_tag: staging


### PR DESCRIPTION
Conflicts:
    roles/launch_ec2/defaults/main.yml

I've switched the instance type from m3 to m4. This adds .5 GB of RAM, lowers cost per hour by 1. censt, and allows the use of AWS reserved instances (m3 instances are no longer available for reservation) since the current configuration does not make use of the ephemeral storage of m3.

I'm using an AWS AMI from CHF with a slightly larger disk (20 GB root) so you may wish to adjust the AMI to a DCE managed one.
