### PR TITLE
Update libpng_ver

### DIFF
--- a/roles/imagemagick/defaults/main.yml
+++ b/roles/imagemagick/defaults/main.yml
@@ -4,5 +4,5 @@ install_path: /opt/install
 magick_path: "{{ install_path }}/imagemagick_sources" # needs double-quotes for yaml syntax
 openjpg_ver: '2.1.0'
 libtiff_ver: '4.0.5'
-libpng_ver: '1.6.20'
+libpng_ver: '1.6.23'
 imagemagick_ver: '.' # call the role with imagemagick_ver: '6.8' to get the most recent 6.8 release, '.' to match the newest release 


### PR DESCRIPTION
1.6.20 has been moved to the older-releases subfolder.  1.6.23 appears to be the most recent 1.6.x version: https://sourceforge.net/projects/libpng/files/libpng16/
