### PR TITLE
Fixes Solr version check in cases where version number has 2 digits.

### DIFF
--- a/roles/hydra-stack/install/tasks/main.yml
+++ b/roles/hydra-stack/install/tasks/main.yml
@@ -6,7 +6,7 @@
 #
 - include: tomcat.yml
 - include: solr_5.yml
-  when: solr_version | match("^5\.[0-9]\.[0-9]")
+  when: solr_version | match("^5\.\d{1,2}\.{1,2}")
 - include: solr_4.yml
-  when: solr_version | match("^4\.[0-9]\.[0-9]")
+  when: solr_version | match("^4\.\d{1-2}\.\d{1-2}")
 - include: fedora.yml

--- a/roles/hydra-stack/install/tasks/main.yml
+++ b/roles/hydra-stack/install/tasks/main.yml
@@ -6,7 +6,7 @@
 #
 - include: tomcat.yml
 - include: solr_5.yml
-  when: solr_version | match("^5\.\d{1,2}\.{1,2}")
+  when: solr_version | match("^[5-9]\.\d{1,2}\.\d{1,2}")
 - include: solr_4.yml
   when: solr_version | match("^4\.\d{1-2}\.\d{1-2}")
 - include: fedora.yml


### PR DESCRIPTION
This should fix issues where Solr versions with 2 digit numbers (only the 4.10 line so far) cause breaks in the version check.
Fixes issue #132 
