### PR TITLE
Add elastic variable to toggle assignment of EIP or normal public IP on EC2 creation

### DIFF
--- a/group_vars/sample_all
+++ b/group_vars/sample_all
@@ -10,6 +10,7 @@ ec2_key: my_ec2_key
 ec2_access_key: my_ec2_access_key
 ec2_secret_key: my_ec2_secret_key
 ec2_security_group: my_ec2_security_group
+elastic: True
 # used in capistrano_setup, system_setup roles
 #keys_to_add:
 # used in sufia_dependencies role

--- a/roles/launch_ec2/tasks/main.yml
+++ b/roles/launch_ec2/tasks/main.yml
@@ -11,7 +11,7 @@
     aws_access_key: "{{ ec2_access_key }}"
     aws_secret_key: "{{ ec2_secret_key }}"
     vpc_subnet_id: "{{ vpc_subnet_id }}"
-    # assign_public_ip: yes
+    assign_public_ip: yes
     group_id: "{{ ec2_security_group }}"
     instance_type: "{{ ec2_instance_type }}"
     image: "{{ ec2_image }}"
@@ -37,21 +37,26 @@
     region: "{{ ec2_region }}"
     aws_access_key: "{{ ec2_access_key }}"
     aws_secret_key: "{{ ec2_secret_key }}"
-  register: instance_eip
+  register: instance_pip
+  when: elastic
 
-- debug: var=instance_eip.public_ip
+#This has to come after elastic IP due to register's behavior on skips
+- name: Set non-elastic IP of instance
+  set_fact:
+    instance_pip: "{{ ec2.instances[0] }}"
+  when: not elastic
 
 - name: Add all instance public IPs to in-memory host group
-  add_host: hostname={{ instance_eip.public_ip }} groups=newboxes
+  add_host: hostname={{ instance_pip.public_ip }} groups=newboxes
   with_items: ec2.instances
 
 - name: Add all instance public IPs to on-disc host group
-  lineinfile: dest=hosts line={{ instance_eip.public_ip }} insertafter=ec2hosts
+  lineinfile: dest=hosts line={{ instance_pip.public_ip }} insertafter=ec2hosts
   with_items: ec2.instances
 
 - name: give ssh time to come up
-#  wait_for: host={{ item.public_ip }} port=22 state=started
-  wait_for: host={{ instance_eip.public_ip }} port=22 state=started
+  wait_for: host={{ item.public_ip }} port=22 state=started
+  wait_for: host={{ instance_pip.public_ip }} port=22 state=started
   with_items: ec2.instances
 
 - name: pause another few seconds for other services to start

--- a/roles/launch_ec2/tasks/main.yml
+++ b/roles/launch_ec2/tasks/main.yml
@@ -55,7 +55,6 @@
   with_items: ec2.instances
 
 - name: give ssh time to come up
-  wait_for: host={{ item.public_ip }} port=22 state=started
   wait_for: host={{ instance_pip.public_ip }} port=22 state=started
   with_items: ec2.instances
 


### PR DESCRIPTION
This adds an elastic variable (true/false) which either uses the elastic IP assignment or the default AWS public IP assignment if you want a non-elastic machine without needing to comment or uncomment lines.
The default group_vars is set to True for using Elastic IPs.
