### PR TITLE
gets rid of deprecated usage

### DIFF
--- a/roles/launch_ec2/tasks/main.yml
+++ b/roles/launch_ec2/tasks/main.yml
@@ -6,22 +6,22 @@
 
 - name: provision an ec2 instance
   ec2:
-    key_name: "{{ ec2_key }}" 
-    region: "{{ ec2_region }}"
-    aws_access_key: "{{ ec2_access_key }}"
-    aws_secret_key: "{{ ec2_secret_key }}"
-    vpc_subnet_id: "{{ vpc_subnet_id }}"
+    key_name: '{{ ec2_key }}' 
+    region: '{{ ec2_region }}'
+    aws_access_key: '{{ ec2_access_key }}'
+    aws_secret_key: '{{ ec2_secret_key }}'
+    vpc_subnet_id: '{{ vpc_subnet_id }}'
     assign_public_ip: yes
-    group_id: "{{ ec2_security_group }}"
-    instance_type: "{{ ec2_instance_type }}"
-    image: "{{ ec2_image }}"
+    group_id: '{{ ec2_security_group }}'
+    instance_type: '{{ ec2_instance_type }}'
+    image: '{{ ec2_image }}'
     wait: true
     count: 1
     state: present
     count_tag:
-      Name: "{{ aws_tag }}"
+      Name: '{{ aws_tag }}'
     instance_tags: 
-      Name: "{{ aws_tag }}"
+      Name: '{{ aws_tag }}'
     volumes:
           - device_name: /dev/sdf
             volume_size: 40
@@ -33,30 +33,30 @@
     in_vpc: yes
     reuse_existing_ip_allowed: yes
     state: present
-    instance_id: "{{ ec2.instance_ids[0] }}"
-    region: "{{ ec2_region }}"
-    aws_access_key: "{{ ec2_access_key }}"
-    aws_secret_key: "{{ ec2_secret_key }}"
+    device_id: '{{ ec2.instance_ids[0] }}'
+    region: '{{ ec2_region }}'
+    aws_access_key: '{{ ec2_access_key }}'
+    aws_secret_key: '{{ ec2_secret_key }}'
   register: instance_pip
   when: elastic
 
 #This has to come after elastic IP due to register's behavior on skips
 - name: Set non-elastic IP of instance
   set_fact:
-    instance_pip: "{{ ec2.instances[0] }}"
+    instance_pip: '{{ ec2.instances[0] }}'
   when: not elastic
 
 - name: Add all instance public IPs to in-memory host group
-  add_host: hostname={{ instance_pip.public_ip }} groups=newboxes
-  with_items: ec2.instances
+  add_host: hostname='{{ instance_pip.public_ip }}' groups=newboxes
+  with_items: '{{ ec2.instances }}'
 
 - name: Add all instance public IPs to on-disc host group
-  lineinfile: dest=hosts line={{ instance_pip.public_ip }} insertafter=ec2hosts
-  with_items: ec2.instances
+  lineinfile: dest=hosts line='{{ instance_pip.public_ip }}' insertafter=ec2hosts
+  with_items: '{{ ec2.instances }}'
 
 - name: give ssh time to come up
-  wait_for: host={{ instance_pip.public_ip }} port=22 state=started
-  with_items: ec2.instances
+  wait_for: host='{{ instance_pip.public_ip }}' port=22 state=started
+  with_items: '{{ ec2.instances }}'
 
 - name: pause another few seconds for other services to start
   pause: seconds=5


### PR DESCRIPTION
Takes care of this deprecation warning:

```
 TASK [launch_ec2 : associate EIP with instance] ********************************
changed: [localhost]
 [WARNING]: instance_id is no longer used, please use device_id going forward
```

and the warning about bare variables in with_items, which was triggered in three tasks:

```
[DEPRECATION WARNING]: Using bare variables is deprecated. Update your playbooks so that the environment value uses the full variable syntax ('{{ec2.instances}}'). This feature will be removed in a future release. Deprecation 
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

While I was at it, I used single quotes throughout this task, because the combination of double quotes and single quotes looked untidy.
