### PR TITLE
includes should have names

### DIFF
--- a/roles/app-config/tasks/main.yml
+++ b/roles/app-config/tasks/main.yml
@@ -2,5 +2,8 @@
 # Role: app-config
 # roles/app-config/tasks/main.yml
 
-- include: systems.yml
-- include: initializers.yml
+- name: log rotation and ssh config
+  include: systems.yml
+
+- name: custom initializers
+  include: initializers.yml

--- a/roles/ec2/tasks/main.yml
+++ b/roles/ec2/tasks/main.yml
@@ -4,6 +4,11 @@
 #
 # sets up standard users, backups, and cron jobs for production (-like) enviroronment
 
-- include: ec2_housekeeping.yml
-- include: ec2_crons.yml
-- include: ec2_ubuntu_user.yml
+- name: ec2-consistent-snapshot
+  include: ec2_housekeeping.yml
+
+- name: snapshot scripts and cron jobs
+  include: ec2_crons.yml
+
+- name: ubuntu user keys
+  include: ec2_ubuntu_user.yml

--- a/roles/ffmpeg/tasks/main.yml
+++ b/roles/ffmpeg/tasks/main.yml
@@ -2,13 +2,32 @@
 # ROLE: ffmpeg
 # roles/ffmpeg/tasks/main.yml 
 
-- include: ff_libraries.yml
-- include: yasm.yml
-- include: x264.yml
-- include: libfdk_aac.yml
-- include: libmp3lame.yml
-- include: libopus.yml
-- include: libogg.yml
-- include: libvorbis.yml
-- include: libvpx.yml
-- include: ffmpeg.yml
+- name: ffmpeg libraries
+  include: ff_libraries.yml
+
+- name: yasm
+  include: yasm.yml
+
+- name: x264
+  include: x264.yml
+
+- name: libfdk_aac
+  include: libfdk_aac.yml
+
+- name: libmp2lame
+  include: libmp3lame.yml
+
+- name: libopus
+  include: libopus.yml
+
+- name: libogg
+  include: libogg.yml
+
+- name: libvorbis
+  include: libvorbis.yml
+
+- name: libvpx
+  include: libvpx.yml
+
+- name: ffmpeg
+  include: ffmpeg.yml

--- a/roles/hydra-stack/install/tasks/main.yml
+++ b/roles/hydra-stack/install/tasks/main.yml
@@ -4,9 +4,16 @@
 #
 # installs solr and fedora in production mode as servlets under tomcat
 #
-- include: tomcat.yml
-- include: solr_5.yml
+- name: tomcat
+  include: tomcat.yml
+
+- name: solr 5.x
+  include: solr_5.yml
   when: solr_version | match("^[5-9]\.\d{1,2}\.\d{1,2}")
-- include: solr_4.yml
+
+- name: solr 4.x
+  include: solr_4.yml
   when: solr_version | match("^4\.\d{1-2}\.\d{1-2}")
-- include: fedora.yml
+
+- name: fedora
+  include: fedora.yml

--- a/roles/imagemagick/tasks/main.yml
+++ b/roles/imagemagick/tasks/main.yml
@@ -7,8 +7,17 @@
 #   EG:
 #     - { role: imagemagick, imagemagick_ver: '6.6' }   # will install the highest version matching the 6.6 prefix
 
-- include: im_libraries.yml
-- include: openjpg.yml
-- include: libtiff.yml
-- include: libpng.yml
-- include: imagemagick.yml
+- name: imagemagick libraries
+  include: im_libraries.yml
+
+- name: openjpg
+  include: openjpg.yml
+
+- name: libtiff
+  include: libtiff.yml
+
+- name: libpng
+  include: libpng.yml
+
+- name: imagemagick
+  include: imagemagick.yml

--- a/roles/sufia_dependencies/install/tasks/database.yml
+++ b/roles/sufia_dependencies/install/tasks/database.yml
@@ -1,7 +1,9 @@
 ---
 # installs rails database and supporting libraries - psql or mysql
-- include: mysql.yml
+- name: mysql
+  include: mysql.yml
   when: db == "mysql2"
 
-- include: postgresql.yml
+- name: postgresql
+  include: postgresql.yml
   when: db == "postgresql"

--- a/roles/sufia_dependencies/install/tasks/main.yml
+++ b/roles/sufia_dependencies/install/tasks/main.yml
@@ -4,6 +4,11 @@
 #
 # includes tasks to install dependencies specific to sufia (but not hydra generally)
 #
-- include: fits.yml
-- include: redis_resque.yml
-- include: database.yml
+- name: fits
+  include: fits.yml
+
+- name: redis and resque 
+  include: redis_resque.yml
+
+- name: postgresql or mysql
+  include: database.yml

--- a/roles/webserver/install/tasks/main.yml
+++ b/roles/webserver/install/tasks/main.yml
@@ -6,8 +6,10 @@
 # see webserver/configure role for local configuration files
 #
 
-- include: passenger.yml
+- name: passenger
+  include: passenger.yml
   when: webserver == "passenger"
 
-- include: puma.yml
+- name: puma
+  include: puma.yml
   when: webserver == "puma"


### PR DESCRIPTION
With Ansible version >=1.0.2, adding names to include tasks allows more granular restarts when a playbook fails or gets interrupted. With these changes, we can do `--start-at-task="ffmpeg : yasm"` and Ansible will start by including `roles/ffmpeg/tasks/yasm.yml` and clone the yasm source code. Note that Ansible will not start at a task within the included yaml file; `--start-at-task="ffmpeg : clone yasm source"` still won't work.
