### PR TITLE
adds hostname to /etc/hosts, sets pattern for future networking/architecture tasks

### DIFF
--- a/roles/networking/tasks/main.yml
+++ b/roles/networking/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+# Role: networking
+# roles/networking/tasks/main.yml
+# 
+# Placeholder for architecture/networking options
+#
+
+- name: check hostname
+  become: yes
+  shell:  hostname -s
+  register: hostname
+
+- name: make sure /etc/hosts includes hostname
+  become: yes
+  lineinfile: line="127.0.0.1 {{ hostname.stdout }}" dest=/etc/hosts state=present


### PR DESCRIPTION
On many ec2 images the hostname is set to the internal IP by default. This can cause an annoying error:

```
sudo: unable to resolve host ip-10-0-0-207
```

My proposed fix uses the public IP as the default hostname for ec2 builds - this can be overwritten by later roles/tasks. 

Note: Ansible offers a `hostname` module, but it doesn't work on the ec2 Debian image yet, so I'm using `shell` instead. 
