### PR TITLE
Supported versions expansion

### DIFF
--- a/roles/hydra-stack/install/defaults/main.yml
+++ b/roles/hydra-stack/install/defaults/main.yml
@@ -15,6 +15,8 @@ solr_context: solr
 project_name: sufia-project
 app_root: /opt/{{ project_name }}/current
 fedora_version: 4.1.0
+#fedora_database only used in Fedora versions >= 4.6.0
+fedora_database: minimal-default
 #solr_version: 4.10.4
 solr_version: 5.5.0
 # Default solr collection

--- a/roles/hydra-stack/install/tasks/fedora.yml
+++ b/roles/hydra-stack/install/tasks/fedora.yml
@@ -20,9 +20,15 @@
   command: cp {{ install_path }}/fcrepo-webapp-{{ fedora_version }}.war {{ tomcat_path }}/webapps/fedora.war
   when: fedora_war.stat.exists == False
 
-- name: create tomcat config and java options
+- name: create tomcat config and java options for Fedora 4-4.5
   become: yes
   template: src=tomcat7.j2 dest=/etc/default/{{ tomcat }} backup=yes
+  when: fedora_version | match("^4\.[0-5]\.[0-9]")
+
+- name: create tomcat config and java options for Fedora 4.6
+  become: yes
+  template: src=tomcat7_fc4_6.j2 dest=/etc/default/{{ tomcat }} backup=yes
+  when: fedora_version | match("^4\.6\.[0-9]")
 
 - name: restart tomcat
   become: yes

--- a/roles/hydra-stack/install/tasks/main.yml
+++ b/roles/hydra-stack/install/tasks/main.yml
@@ -13,7 +13,8 @@
 
 - name: solr 4.x
   include: solr_4.yml
-  when: solr_version | match("^4\.\d{1-2}\.\d{1-2}")
+  when: solr_version | match("^4\.\d{1,2}\.\d{1,2}")
 
 - name: fedora
   include: fedora.yml
+

--- a/roles/hydra-stack/install/templates/tomcat7_fc4_6.j2
+++ b/roles/hydra-stack/install/templates/tomcat7_fc4_6.j2
@@ -1,0 +1,5 @@
+# A backup of the original file with addition options is at /etc/default/tomcat7.bak
+TOMCAT7_USER=tomcat7
+TOMCAT7_GROUP=tomcat7
+JAVA_HOME={{ java_home }}
+JAVA_OPTS="-Dfcrepo.home=/opt/fedora-data -Dfcrepo.modeshape.configuration=classpath:/config/{{ fedora_database }}/repository.json -Djava.awt.headless=true -XX:+UseG1GC -XX:+UseCompressedOops -XX:-UseLargePagesIndividualAllocation -XX:MaxPermSize={{ tomcat_permgen_memory }} -Xms{{ tomcat_min_memory }} -Xmx{{ tomcat_max_memory }} -Djava.util.logging.config.file=/etc/tomcat7/logging.properties -server"

--- a/roles/imagemagick/tasks/libpng.yml
+++ b/roles/imagemagick/tasks/libpng.yml
@@ -1,6 +1,11 @@
 ---
 - name: download libpng source
   get_url: url=http://downloads.sourceforge.net/project/libpng/libpng16/{{ libpng_ver }}/libpng-{{ libpng_ver }}.tar.gz dest={{ magick_path }}/libpng-{{ libpng_ver }}.tar.gz
+  when: libpng_ver | match("1\.6\.2[4-5]")
+
+- name: download older libpng source
+  get_url: url=http://sourceforge.net/projects/libpng/files/libpng16/older-releases/{{ libpng_ver }}/libpng-{{ libpng_ver }}.tar.gz dest={{ magick_path }}/libpng-{{ libpng_ver }}.tar.gz
+  when: libpng_ver | match("1\.6\.[0-9](?![0-9])|1\.6\.1[0-9]|1\.6\.2[0-3]")
 
 - name: unzip libpng source
   unarchive: src={{ magick_path }}/libpng-{{ libpng_ver }}.tar.gz dest={{ magick_path }}/ creates={{ magick_path }}/libpng-{{ libpng_ver }} copy=no

--- a/roles/sufia_dependencies/install/tasks/fits.yml
+++ b/roles/sufia_dependencies/install/tasks/fits.yml
@@ -31,7 +31,9 @@
 - name: set FITS_HOME in fits-env.sh
   become: yes
   lineinfile: dest=/usr/local/lib/fits-{{ fits_version }}/fits-env.sh regexp=^FITS_HOME line=FITS_HOME="/usr/local/lib/fits-{{ fits_version }}" state=present
+  when: fits_version | match("^0\.([8-9]|10)\.[0-9]|1\.[0-9]\.[0-9]")
 
 - name: symlink fits-env.sh alias
   become: yes
   file: src=/usr/local/lib/fits-{{ fits_version }}/fits-env.sh dest=/usr/local/bin/fits-env.sh state=link
+  when: fits_version | match("^0\.([8-9]|10)\.[0-9]|1\.[0-9]\.[0-9]")


### PR DESCRIPTION
This adds support for Fedora 4.6.0 (only using the default modeshape DB for now), pre .0.8.x versions of FITS, and older libpng versions. It will add a need to update the regex on those three if there are notable version changes.
