### PR TITLE
Configure apache ServerName globally

### DIFF
--- a/roles/webserver/config/templates/apache_ssl_config.j2
+++ b/roles/webserver/config/templates/apache_ssl_config.j2
@@ -4,9 +4,10 @@
 # THEY SHOULD BE MADE PERMANENT.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
+ServerName {{ server_name }}
+
 <VirtualHost *:443>
   PassengerAppEnv {{ rails_env }}
-  ServerName {{ server_name }}
   # !!! Be sure to point DocumentRoot to 'public'!
   DocumentRoot {{ app_root }}/public
   # allows forward slashes for IIIF

--- a/roles/webserver/config/templates/passenger_config.j2
+++ b/roles/webserver/config/templates/passenger_config.j2
@@ -3,9 +3,11 @@
 # MANAGER IS RUN. MAKE SURE YOU REFLECT CHANGES IN THE ANSIBLE SCRIPTS IF
 # THEY SHOULD BE MADE PERMANENT.
 # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+ServerName {{ server_name }}
+
 <VirtualHost *:80>
   PassengerAppEnv {{ rails_env }}
-  ServerName {{ server_name }}
   # !!! Be sure to point DocumentRoot to 'public'!
   DocumentRoot {{ app_root }}/public
   # allows forward slashes for IIIF


### PR DESCRIPTION
Fixes the following apache complaint:
```
AH00558: apache2: Could not reliably determine the server's fully qualified domain name, using 127.0.0.1. Set the 'ServerName' directive globally to suppress this message```