### PR TITLE
Add conditional to protect apache boots when mod_rewrite not enabled

### DIFF
--- a/roles/webserver/config/templates/apache_ssl_config.j2
+++ b/roles/webserver/config/templates/apache_ssl_config.j2
@@ -14,12 +14,14 @@ ServerName {{ server_name }}
   AllowEncodedSlashes NoDecode
 
   # Settings compatible with https://github.com/capistrano/maintenance
-  RewriteEngine On
-  ErrorDocument 503 /system/maintenance.html
-  # Return 503 error if the maintenance page exists.
-  RewriteCond %{DOCUMENT_ROOT}/system/maintenance.html -f
-  RewriteCond %{SCRIPT_FILENAME} !maintenance.html
-  RewriteRule ^.*$ - [L,R=503]
+  <IfModule mod_rewrite.c>
+    RewriteEngine On
+    ErrorDocument 503 /system/maintenance.html
+    # Return 503 error if the maintenance page exists.
+    RewriteCond %{DOCUMENT_ROOT}/system/maintenance.html -f
+    RewriteCond %{SCRIPT_FILENAME} !maintenance.html
+    RewriteRule ^.*$ - [L,R=503]
+  </IfModule>
 
   <Directory {{ app_root }}/public>
         # MultiViews must be turned off.

--- a/roles/webserver/config/templates/passenger_config.j2
+++ b/roles/webserver/config/templates/passenger_config.j2
@@ -14,12 +14,14 @@ ServerName {{ server_name }}
   AllowEncodedSlashes NoDecode
 
   # Settings compatible with https://github.com/capistrano/maintenance
-  RewriteEngine On
-  ErrorDocument 503 /system/maintenance.html
-  # Return 503 error if the maintenance page exists.
-  RewriteCond %{DOCUMENT_ROOT}/system/maintenance.html -f
-  RewriteCond %{SCRIPT_FILENAME} !maintenance.html
-  RewriteRule ^.*$ - [L,R=503]
+  <IfModule mod_rewrite.c>
+    RewriteEngine On
+    ErrorDocument 503 /system/maintenance.html
+    # Return 503 error if the maintenance page exists.
+    RewriteCond %{DOCUMENT_ROOT}/system/maintenance.html -f
+    RewriteCond %{SCRIPT_FILENAME} !maintenance.html
+    RewriteRule ^.*$ - [L,R=503]
+  </IfModule>
 
   <Directory {{ app_root }}/public>
         # MultiViews must be turned off.


### PR DESCRIPTION
@acozine turns out #159 breaks the build because mod_rewrite is not enabled by the rest of the scripts. @sanfordd says this must be done differently for ubuntu and CentOS. Here is a fix in the meantime!