### PR TITLE
Adds option for using local source for image libraries

### DIFF
--- a/roles/imagemagick/defaults/main.yml
+++ b/roles/imagemagick/defaults/main.yml
@@ -1,8 +1,10 @@
 ---
 # roles/imagemagick/defaults/main.yml 
 install_path: /opt/install
+local_magick: ~/Downloads
 magick_path: "{{ install_path }}/imagemagick_sources" # needs double-quotes for yaml syntax
 openjpg_ver: '2.1.0'
 libtiff_ver: '4.0.5'
-libpng_ver: '1.6.25'
+libpng_ver: '1.6.28'
 imagemagick_ver: '.' # call the role with imagemagick_ver: '6.8' to get the most recent 6.8 release, '.' to match the newest release 
+local_im_release: '7.0.4-4'

--- a/roles/imagemagick/tasks/imagemagick.yml
+++ b/roles/imagemagick/tasks/imagemagick.yml
@@ -1,6 +1,10 @@
 ---
 # Note: this code assumes that valid imagemagick releases are in tar-zip format.  It appears that future releases may switch to 7zip format...
 
+- name: Check for local release
+  local_action: stat path="{{ local_magick }}/ImageMagick-{{ local_im_release }}.tar.xz"
+  register: local_copy
+
 - name: find latest matching release {{ imagemagick_ver | default('') }} number
   # get the list of release downloads
   # filter for matching versions: '' = everything, '6' = any 6.x version, '6.8' = any 6.8.y version, 
@@ -8,7 +12,13 @@
   # take the most recent
   shell: curl http://www.imagemagick.org/download/releases/ | grep -o -P '[0-9]+[.][0-9]+[.][0-9]+-[0-9]+(?=\.tar)' | grep {{ imagemagick_ver }} | sort -V | tail -n 1 
   register: im_release  # .content contains a string like 6.8.3-10
-  
+  when: local_copy.stat.exists == False
+
+- name: Convert local release to stdout
+  shell: echo "{{ local_im_release }}"
+  when: local_copy.stat.exists == True
+  register: im_release
+
 - name: set archive filename
   set_fact: im_zip=ImageMagick-{{ im_release.stdout }}.tar.xz
   
@@ -17,6 +27,13 @@
   
 - name: download release
   get_url: url=http://www.imagemagick.org/download/releases/{{ im_zip }} dest={{ magick_path }}/{{ im_zip }}
+  when: local_copy.stat.exists == False
+
+- name: Copy over local verison
+  copy:
+    src: "{{ local_magick }}/ImageMagick-{{ local_im_release }}.tar.xz"
+    dest: "{{ magick_path }}/{{ im_zip }}"
+  when: local_copy.stat.exists == True
 
 - name: unzip tarball
   unarchive: src={{ magick_path }}/{{ im_zip }} dest={{ magick_path }} copy=no

--- a/roles/imagemagick/tasks/libpng.yml
+++ b/roles/imagemagick/tasks/libpng.yml
@@ -1,11 +1,20 @@
 ---
-- name: download libpng source
-  get_url: url=http://downloads.sourceforge.net/project/libpng/libpng16/{{ libpng_ver }}/libpng-{{ libpng_ver }}.tar.gz dest={{ magick_path }}/libpng-{{ libpng_ver }}.tar.gz
-  when: libpng_ver | match("1\.6\.2[4-5]")
+- name: check for local libpng
+  local_action: stat path="{{ local_magick }}/libpng-{{ libpng_ver }}.tar.gz"
+  register: libpng
 
-- name: download older libpng source
-  get_url: url=http://sourceforge.net/projects/libpng/files/libpng16/older-releases/{{ libpng_ver }}/libpng-{{ libpng_ver }}.tar.gz dest={{ magick_path }}/libpng-{{ libpng_ver }}.tar.gz
-  when: libpng_ver | match("1\.6\.[0-9](?![0-9])|1\.6\.1[0-9]|1\.6\.2[0-3]")
+- name: copy libpng source
+  copy: 
+    src: "{{ local_magick }}/libpng-{{ libpng_ver }}.tar.gz"
+    dest: "{{ magick_path }}/libpng-{{ libpng_ver }}.tar.gz"
+  when: 
+    - libpng.stat.exists == True
+
+- name: download libpng source
+  get_url: 
+    url: http://downloads.sourceforge.net/project/libpng/libpng16/{{ libpng_ver }}/libpng-{{ libpng_ver }}.tar.gz 
+    dest: "{{ magick_path }}/libpng-{{ libpng_ver }}.tar.gz"
+    force: no
 
 - name: unzip libpng source
   unarchive: src={{ magick_path }}/libpng-{{ libpng_ver }}.tar.gz dest={{ magick_path }}/ creates={{ magick_path }}/libpng-{{ libpng_ver }} copy=no

--- a/roles/imagemagick/tasks/libtiff.yml
+++ b/roles/imagemagick/tasks/libtiff.yml
@@ -1,6 +1,20 @@
 ---
+- name: check for local libtiff
+  local_action: stat path="{{ local_magick }}/tiff-{{ libtiff_ver }}.tar.gz"
+  register: libtiff
+
+- name: copy libtiff source
+  copy: 
+    src: "{{ local_magick }}/tiff-{{ libtiff_ver }}.tar.gz"
+    dest: "{{ magick_path }}/tiff-{{ libtiff_ver }}.tar.gz"
+  when:
+    - libtiff.stat.exists == True
+
 - name: download libtiff source
-  get_url: url=http://download.osgeo.org/libtiff/tiff-{{ libtiff_ver }}.tar.gz dest={{ magick_path }}/tiff-{{ libtiff_ver }}.tar.gz
+  get_url: 
+    url: http://download.osgeo.org/libtiff/tiff-{{ libtiff_ver }}.tar.gz 
+    dest: "{{ magick_path }}/tiff-{{ libtiff_ver }}.tar.gz"
+    force: no
 
 - name: unzip libtiff source
   unarchive: src={{ magick_path }}/tiff-{{ libtiff_ver }}.tar.gz dest={{ magick_path }}/ creates={{ magick_path }}/tiff-{{ libtiff_ver }} copy=no

--- a/roles/imagemagick/tasks/openjpg.yml
+++ b/roles/imagemagick/tasks/openjpg.yml
@@ -1,6 +1,21 @@
 ---
+- name: check for local openjpg
+  local_action: stat path="{{ local_magick }}/openjpeg-{{ openjpg_ver }}.tar.gz"
+  register: openjpg
+
+
+- name: copy openjpg source
+  copy: 
+    src: "{{ local_magick }}/openjpeg-{{ openjpg_ver }}.tar.gz"
+    dest: "{{ magick_path }}/openjpeg-{{ openjpg_ver }}.tar.gz"
+  when:
+    - openjpg.stat.exists  == True
+
 - name: download openjpg source
-  get_url: url=http://downloads.sourceforge.net/project/openjpeg.mirror/{{ openjpg_ver }}/openjpeg-{{ openjpg_ver }}.tar.gz dest={{ magick_path }}/openjpeg-{{ openjpg_ver }}.tar.gz
+  get_url: 
+    url: http://downloads.sourceforge.net/project/openjpeg.mirror/{{ openjpg_ver }}/openjpeg-{{ openjpg_ver }}.tar.gz 
+    dest: "{{ magick_path }}/openjpeg-{{ openjpg_ver }}.tar.gz"
+    force: no
 
 - name: unzip openjpg source
   unarchive: src={{ magick_path }}/openjpeg-{{ openjpg_ver }}.tar.gz dest={{ magick_path }}/ creates={{ magick_path }}/openjpeg-version.{{ openjpg_ver }} copy=no
@@ -14,3 +29,4 @@
 - name: install openjpg
   become: yes
   shell: cd {{ magick_path }}/openjpeg-{{ openjpg_ver }} && make install
+...


### PR DESCRIPTION
Allows for local copying of libpng, libtiff, and openjpg to reduce problems with sourceforge's slow response erroring out deployments.
Also removes the old version regex check for the above libraries since they can now be maintained locally if needed.
Fixes #166 