### PR TITLE
Default ports and group name added. Spacing error fixed.

### DIFF
--- a/roles/launch_ec2/defaults/main.yml
+++ b/roles/launch_ec2/defaults/main.yml
@@ -4,3 +4,6 @@ ec2_region: us-east-1
 ec2_instance_type: m4.medium # a moderate instance size 
 ec2_image: ami-a95f79c3 # ubuntu 14.04 LTS 64-bit for us-east-1
 aws_tag: staging
+solr_port: 8983
+fedora_port: 8080
+internal_network: Internal Network

--- a/roles/launch_ec2/tasks/internal_group.yml
+++ b/roles/launch_ec2/tasks/internal_group.yml
@@ -30,8 +30,8 @@
           group_id: '{{ internal_network }}'
           
         - proto: tcp
-          from_port: '{{  solr_port }}'
-          to_port: '{{  solr_port }}'
+          from_port: '{{ solr_port }}'
+          to_port: '{{ solr_port }}'
           group_id: '{{ internal_network }}'
 
 ...


### PR DESCRIPTION
Added default values for ports and group names for the ec2 networking, and fixed a problem with the solr variable having a pointless space in it.