### PR TITLE
Ensure aptitude is installed on minimal Ubuntu builds

### DIFF
--- a/roles/packages/tasks/main.yml
+++ b/roles/packages/tasks/main.yml
@@ -14,10 +14,13 @@
       (ansible_distribution == "Debian")
 
 - name: install aptitude
-  # on Debian Jessie aptitude is not installed by default, without it apt-get upgrade fails
+  # on Debian Jessie and certain minimal Ubuntu builds aptitude is not installed
+  # without aptitude installed `apt-get upgrade` fails
   become: yes
   package: name=aptitude state=installed
-  when: ansible_distribution == "Debian"
+  when:
+      (ansible_distribution == "Ubuntu") or
+      (ansible_distribution == "Debian")
 
 - name: upgrade apt packages
   become: yes


### PR DESCRIPTION
I was building an new hydra camp box using a minimal Ubuntu 16.04 LTS base box from https://atlas.hashicorp.com/ubuntu/boxes/xenial64 and found that it doesn't have aptitude
installed by default either.  I'm assuming there's no harm running this task on a box that 
already has aptitude installed.