### PR TITLE
Solr JVM configuration

### DIFF
--- a/roles/solr/defaults/main.yml
+++ b/roles/solr/defaults/main.yml
@@ -13,5 +13,6 @@ solr_context: solr
 solr_core: collection1
 solr_port: 8983
 solr_version: 6.4.1
-solr_min_mem: 512m
-solr_max_mem: 1024m
+#Solr mem values are in MB.
+solr_min_mem: 512
+solr_max_mem: 1024

--- a/roles/solr/defaults/main.yml
+++ b/roles/solr/defaults/main.yml
@@ -13,3 +13,5 @@ solr_context: solr
 solr_core: collection1
 solr_port: 8983
 solr_version: 6.4.1
+solr_min_mem: 512m
+solr_max_mem: 1024m

--- a/roles/solr/tasks/standalone_solr.yml
+++ b/roles/solr/tasks/standalone_solr.yml
@@ -50,6 +50,12 @@
     regexp: '^#SOLR_JAVA_MEM|^SOLR_JAVA_MEM'
     line: SOLR_JAVA_MEM="-Xms{{ solr_min_mem }}m -Xmx{{ solr_max_mem }}m"
 
+- name: restart solr service
+  become: yes
+  service: 
+    name: solr
+    state: restarted
+
 - name: set solr to restart on reboot
   become: yes
   service: name=solr enabled=yes

--- a/roles/solr/tasks/standalone_solr.yml
+++ b/roles/solr/tasks/standalone_solr.yml
@@ -42,6 +42,14 @@
   become: yes
   file: src={{ app_root }}/solr/config/solrconfig.xml dest=/var/solr/data/{{ solr_core }}/conf/solrconfig.xml state=link force=yes
 
+- name: Set JVM heap size
+  become: yes
+  lineinfile:
+    path: /etc/default/solr.in.sh
+    state: present
+    regexp: '^#SOLR_JAVA_MEM|^SOLR_JAVA_MEM'
+    line: SOLR_JAVA_MEM="-Xms{{ solr_min_mem }}m -Xmx{{ solr_max_mem }}m"
+
 - name: set solr to restart on reboot
   become: yes
   service: name=solr enabled=yes


### PR DESCRIPTION
Solves issue #179 on standalone Solr.
Skipped the SOLR_HEAP value for the SOLR_JAVA_MEM value to give a bit more control for configuration in the end.
This wasn't tweaked for Solr 4 due to the Tomcat configuration being a bit different from solr as a standalone service and not being sure how to balance that with Fedora yet.