### PR TITLE
Regex fix for getting versions of ImageMagick ending in 2 digit numbers.

### DIFF
--- a/roles/imagemagick/tasks/web_IM.yml
+++ b/roles/imagemagick/tasks/web_IM.yml
@@ -17,7 +17,7 @@
     # '6' = any 6.x version, '6.8' = any 6.8.y version,
     # '6.8.1-9' = exact match (use exact with caution since they become obsolete quickly)
     # take the most recent
-  shell: echo {{ im_clean_list | quote }} | grep -o -P '[0-9]+[.][0-9]+[.][0-9]+-[0-9]' | grep {{ imagemagick_ver }} | sort -V | tail -n 1
+  shell: echo {{ im_clean_list | quote }} | grep -o -P '[0-9]+[.][0-9]+[.][0-9]+-\d{1,2}' | grep {{ imagemagick_ver }} | sort -V | tail -n 1
   register: im_release
 
 - name: set zip archive filename


### PR DESCRIPTION
Closes #212 