### PR TITLE
Set default disk mount owner to ansible_ssh_user

### DIFF
--- a/roles/mount_disks/defaults/main.yml
+++ b/roles/mount_disks/defaults/main.yml
@@ -1,4 +1,7 @@
 #These defaults also need to be changed in the launch_ec2 role which builds the volume.
+disk_owner: "{{ ansible_ssh_user }}"
+disk_group: "{{ ansible_ssh_user }}"
+
 aws_vol:
   /dev/xvdf:
     size: 40
@@ -7,5 +10,5 @@ aws_vol:
     mount: /opt
     fs: ext4
     perm: 755
-    owner: ubuntu
-    group: ubuntu
+    owner: "{{ disk_owner }}"
+    group: "{{ disk_group }}"


### PR DESCRIPTION
Closes #211 
Set it to disk_owner and disk_group which refer to the ansible_ssh_user to make it easier to reassign with a different variable rather than editing the default.
