### PR TITLE
launching instances uses variables for host groups

### DIFF
--- a/roles/launch_ec2/defaults/main.yml
+++ b/roles/launch_ec2/defaults/main.yml
@@ -1,16 +1,18 @@
 ---
 # roles/launch_ec2/defaults/main.yml
-ec2_region: us-east-1
-ec2_instance_type: m4.medium # a moderate instance size 
-ec2_image: ami-a95f79c3 # ubuntu 14.04 LTS 64-bit for us-east-1
 aws_tag: staging
-solr_port: 8983
-fedora_port: 8080
-internal_network: Internal Network
 aws_vol:
   /dev/xvdf:
     size: 40
     type: gp2
     delete: Yes
     mount: /opt
+ec2_region: us-east-1
+ec2_instance_type: m4.medium # a moderate instance size 
+ec2_image: ami-a95f79c3 # ubuntu 14.04 LTS 64-bit for us-east-1
+fedora_port: 8080
+host_group: ec2hosts
+internal_network: Internal Network
+newbox_group: newboxes
+solr_port: 8983
     

--- a/roles/launch_ec2/tasks/machine.yml
+++ b/roles/launch_ec2/tasks/machine.yml
@@ -56,11 +56,11 @@
   when: not elastic
 
 - name: Add all instance public IPs to in-memory host group
-  add_host: hostname='{{ instance_pip.public_ip }}' groups=newboxes
+  add_host: hostname='{{ instance_pip.public_ip }}' groups='{{ newbox_group }}'
   with_items: '{{ ec2.instances }}'
 
 - name: Add all instance public IPs to on-disc host group
-  lineinfile: dest=hosts line='{{ instance_pip.public_ip }}' insertafter=ec2hosts
+  lineinfile: dest=hosts line='{{ instance_pip.public_ip }}' insertafter='{{ host_group }}'
   with_items: '{{ ec2.instances }}'
 
 - name: give ssh time to come up


### PR DESCRIPTION
Defaults remain the same as the old code. Now we can control the host group of each box we spin up.

While I was adding the new variables, I also alphabetized the default variables list.