### PR TITLE
orders packages, adds ClamAV on Ubuntu & Debian

### DIFF
--- a/roles/packages/vars/CentOS.yml
+++ b/roles/packages/vars/CentOS.yml
@@ -19,15 +19,16 @@ packages:
   - rpm-build
   - rpm-sign
   # other packages
-  - ImageMagick-devel
   - curl-devel
   - gdbm-devel
   - git
   - httpd-devel
+  - ImageMagick-devel
   - java-1.8.0-openjdk
   - libffi-devel
-  - libxml2-devel
+  - libreoffice-headless
   - libxslt-devel
+  - libxml2-devel
   - libyaml-devel
   - lsof # needed for solr 5.x service script
   - mysql-devel
@@ -43,6 +44,5 @@ packages:
   # - redis
   # on centos mod_xsendfile is not in the main repos
   # - mod_xsendfile
-  - libreoffice-headless
   # this was in the ubuntu package list
   #    - libxvidcore-dev

--- a/roles/packages/vars/Debian.yml
+++ b/roles/packages/vars/Debian.yml
@@ -1,33 +1,35 @@
 ---
 packages:
   - acl
+  - autoconf
+  - automake
+  - bison
   - build-essential
+  - clamav
+  - clamav-daemon
+  - curl
   - git
   - git-core
-  - curl
-  - openssl
+  - imagemagick
+  - libc6-dev
+  - libcurl4-openssl-dev
+  - libmagickwand-dev
   - libreadline6
   - libreadline6-dev
-  - zlib1g
-  - zlib1g-dev
+  - libreoffice
+  - libsqlite3-dev
   - libssl-dev
-  - libyaml-dev
+  - libtool
   - libxml2-dev
   - libxslt-dev
-  - autoconf
-  - libc6-dev
-  - ncurses-dev
-  - automake
-  - libtool
-  - bison
-  - subversion
-  - pkg-config
-  - libmagickwand-dev
-  - imagemagick
-  - libcurl4-openssl-dev
   - libxvidcore-dev
+  - libyaml-dev
+  - ncurses-dev
+  - openssl
+  - pkg-config
   - redis-server
-  - xfsprogs
-  - libsqlite3-dev
-  - libreoffice
+  - subversion
   - vim
+  - xfsprogs
+  - zlib1g
+  - zlib1g-dev

--- a/roles/packages/vars/Ubuntu.yml
+++ b/roles/packages/vars/Ubuntu.yml
@@ -1,34 +1,36 @@
 ---
 packages:
   - acl
+  - autoconf
+  - automake
+  - bison
   - build-essential
+  - clamav
+  - clamav-daemon
+  - curl
   - git
   - git-core
-  - curl
-  - openssl
+  - imagemagick
+  - libc6-dev
+  - libcurl4-openssl-dev
+  - libgmp3-dev
+  - libmagickwand-dev
   - libreadline6
   - libreadline6-dev
-  - zlib1g
-  - zlib1g-dev
+  - libreoffice
+  - libsqlite3-dev
   - libssl-dev
-  - libyaml-dev
+  - libtool
   - libxml2-dev
   - libxslt-dev
-  - libgmp3-dev
-  - autoconf
-  - libc6-dev
-  - ncurses-dev
-  - automake
-  - libtool
-  - bison
-  - subversion
-  - pkg-config
-  - libmagickwand-dev
-  - imagemagick
-  - libcurl4-openssl-dev
   - libxvidcore-dev
-  - redis-server
+  - libyaml-dev
+  - ncurses-dev
   - nodejs
+  - openssl
+  - pkg-config
+  - redis-server
+  - subversion
   - xfsprogs
-  - libsqlite3-dev
-  - libreoffice
+  - zlib1g
+  - zlib1g-dev


### PR DESCRIPTION
While I was changing the packages lists, I alphabetized them. 

Closes #248. 