### PR TITLE
Rails server should use 0.0.0.0 for VM port forwarding

### DIFF
--- a/roles/vagrant_setup/tasks/main.yml
+++ b/roles/vagrant_setup/tasks/main.yml
@@ -15,3 +15,9 @@
   apt: name={{ item }} state=latest
   with_items:
     - avahi-daemon
+    
+- name: set the interface for rails webservers to listen on
+  become: yes
+  lineinfile:
+    path: /etc/environment
+    line: 'HOST="0.0.0.0"'


### PR DESCRIPTION
**NOTE**
This only impacts playbooks calling the **vagrant_setup** role.