### PR TITLE
Workaround for RVM installer failure

### DIFF
--- a/roles/rvm/tasks/main.yml
+++ b/roles/rvm/tasks/main.yml
@@ -12,8 +12,13 @@
   command: 'gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3'
   
 - name: Install rvm
-  shell: "curl -sSL https://get.rvm.io | bash -s stable --ruby={{ ruby_version }}"
-  
+#  shell: "curl -sSL https://get.rvm.io | bash -s stable --ruby={{ ruby_version }}"
+
+# temporary workaround for the rvm installer to use the stable branch installer while get.rvm.io points to master
+# (see discussion on https://github.com/rvm/rvm/issues/4107)
+# i.e. the get.rvm.io installer currently fails with "__rvm_print_headline: command not found"
+  shell: "curl -sSL https://raw.githubusercontent.com/rvm/rvm/stable/binscripts/rvm-installer | bash -s stable --ruby={{ ruby_version }}"
+
 - name: Install rails version to use for Hydra tutorials
   command: ".rvm/bin/rvm all do gem install rails -v {{ rails_version }}"
 


### PR DESCRIPTION
The get.rvm.io installer currently fails with "__rvm_print_headline: command not found"

See discussion on https://github.com/rvm/rvm/issues/4107 for background on workaround.